### PR TITLE
Add Pharos to Dashboards & Portfolio Trackers

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Web3 data resources, tools, and APIs for developers, researchers, and analysts w
 
 - [DeBank](https://debank.com/) - Multi-chain portfolio tracker with comprehensive DeFi analytics and protocol insights.
 - [Dune Analytics](https://dune.com/) - Community-powered crypto analytics with SQL queries and dashboards.
+- [Pharos](https://pharos.watch/) - Stablecoin analytics dashboard tracking supply, peg stability, liquidity, reserves, yield, and risk signals.
 - [Rotki](https://rotki.com/) - Privacy-preserving, open-source portfolio tracker and analytics tool.
 - [Zapper](https://zapper.fi/) - Multi-chain dashboard for DeFi portfolio management and yield farming optimization.
 - [Zerion](https://zerion.io/) - DeFi portfolio manager with real-time analytics and cross-chain insights.


### PR DESCRIPTION
Adds Pharos as a stablecoin analytics dashboard under Dashboards & Portfolio Trackers.\n\nThe entry follows the list format with a neutral one-line description and a reachable project URL.