### PR TITLE
Add Sharpe API to Data Providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Web3 data resources, tools, and APIs for blockchain developers, researchers, and
 
 - [Covalent](https://www.covalenthq.com/) - Historical datasets, Covalent Unified API: [goldrush API](https://goldrush.dev/).
 - [Moralis](https://moralis.io/) - Web3 development platform with comprehensive data APIs for various blockchains.
+- [Sharpe](https://www.sharpe.ai/docs/api-reference) - Crypto market data API for funding rates, futures, options, arbitrage, narratives, ecosystems, news, and exchange listings.
 - [Space and Time](https://spaceandtime.io/) - Decentralized data warehouse with ZK-based Proof-of-SQL for verifiable queries.
 
 ## ETL Tools


### PR DESCRIPTION
## Summary

- **Category/Section**: Data Providers
- **Resource name**: Sharpe
- **URL**: https://www.sharpe.ai/docs/api-reference
- **Short description**: Crypto market data API for funding rates, futures, options, arbitrage, narratives, ecosystems, news, and exchange listings.
- Optional: OpenAPI spec at https://www.sharpe.ai/openapi.json

## Checklist

- [x] Placed in the correct section and sorted alphabetically
- [x] One-line, neutral description ending with a period
- [x] Uses "ETH" (not "Ethereum") unless part of a proper noun
- [x] No duplicate across the README
- [x] Links resolve (no obvious 404s)
- [x] Follows the format: `- [Name](https://url/) - Description.`

## Motivation

Sharpe provides developer-facing crypto market data beyond spot prices, including funding rates, futures, options, arbitrage opportunities, narratives, ecosystems, news, and exchange listings. The API docs are public and the OpenAPI document is available for integration workflows.